### PR TITLE
Fix tag filtering message

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const runBuildCommand = async (argv) => {
   console.log(chalk.blue("Input: "), chalk.green(argv.input));
   if (argv.tags) {
     console.log(
-      chalk.blue("Filtering match files by tags: "),
+      chalk.blue("Filtering matched files by tags: "),
       chalk.green(argv.tags)
     );
   }

--- a/index.test.js
+++ b/index.test.js
@@ -326,7 +326,7 @@ publish: false
       );
       assert.match(
         result.stdout,
-        /Filtering match files by tags:/,
+        /Filtering matched files by tags:/,
         "Should show tag filtering message"
       );
       assert.match(


### PR DESCRIPTION
## Summary
- update logging to say "Filtering matched files" instead of "match"
- update tests expecting the old message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f732025f0832784476a5db5bd8036