### PR TITLE
Update wiki link and embed docs

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -32,8 +32,9 @@ export const configParser = (
     .use(remarkParse)
     .use(remarkFrontmatter)
     .use(remarkParseFrontmatter)
-    // 1. remarkWikiLink: Parses [[wikiLinks]] and ![[embeds]] into 'wikiLink' mdast nodes.
-    // data.isEmbed will be true for ![[embeds]].
+    // 1. remarkWikiLink: Handles [[wikiLinks]] and outputs 'wikiLink' mdast nodes.
+    // Obsidian-style ![[...]] image embeds are already converted to standard
+    // Markdown images in parseMarkdown, so remark-wiki-link only sees wiki links.
     .use(remarkWikiLink, {
       pageResolver: (name) => [
         path.join(relativePathToInputFolder, normalizePath(name)),
@@ -41,8 +42,8 @@ export const configParser = (
       hrefTemplate: (permalink) => `${permalink}.html`, // Only for non-embed links
     })
     // 2. remarkGfm: Standard GFM processing.
-    // Obsidian image embeds are now pre-processed into standard Markdown images
-    // so no special remark plugin is needed for them here.
+    // Obsidian image embeds are pre-processed into standard Markdown images in
+    // parseMarkdown, so no special remark plugin is needed for them here.
     .use(remarkGfm)
     // 4. Link normalizer for .md extensions in standard links.
     .use(() => (tree) => {


### PR DESCRIPTION
## Summary
- clarify comment about handling of wiki links and image embeds in `parser.js`

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND: Cannot find package 'yargs')*

------
https://chatgpt.com/codex/tasks/task_e_683f730080348327a4f74ed65ecf0f73