### PR TITLE
Add Table of Contents support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ zenmd ...
     - Includes Obsidian-style image syntax `![[image-path.png]]` with smart path resolution: searches current directory first, then recursively through subdirectories.
   - Wiki links: `[[Another Page]] => [Another Page](/another-page)`.
   - Auto header anchor links, so you can navigate to any H2-h5 headers directly.
+  - Table of contents generation when a `## Table of contents` or `## Contents` section is present.
   - Support raw html in markdown
 - Custom html Layout support (any layout.html files at the same level or above will be used, if none found, default layout will be used.)
 - Layout option via `--layout` to select a built-in theme (currently `default`, `matrix` or `cyberpunk`) when no custom layout.html is provided.
@@ -79,6 +80,7 @@ Feel free to create an issue or submit a PR on Github if you notice more deal br
 ## References
 
 - Built with [remark](https://github.com/remarkjs/remark)
+- Table of contents powered by [remark-toc](https://github.com/remarkjs/remark-toc)
 - Default theme used [SimpleCss](https://simplecss.org/)
 - Cyberpunk theme used [Cyberpunk Color Palette
   by mishiki](https://www.color-hex.com/color-palette/14887)

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "remark-parse": "^11.0.0",
         "remark-parse-frontmatter": "^1.0.3",
         "remark-rehype": "^11.0.0",
+        "remark-toc": "^9.0.0",
         "remark-wiki-link": "^2.0.1",
         "unified": "^11.0.4",
         "unist-util-visit": "^5.0.0",
@@ -102,6 +103,12 @@
       "version": "0.7.33",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.33.tgz",
       "integrity": "sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ=="
+    },
+    "node_modules/@types/ungap__structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/ungap__structured-clone/-/ungap__structured-clone-1.2.0.tgz",
+      "integrity": "sha512-ZoaihZNLeZSxESbk9PUAPZOlSpcKx81I1+4emtULDVmBLkYutTcMlCj2K9VNlf9EWODxdO6gkAqEaLorXwZQVA==",
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.1",
@@ -1155,6 +1162,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-toc": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-7.1.0.tgz",
+      "integrity": "sha512-2TVKotOQzqdY7THOdn2gGzS9d1Sdd66bvxUyw3aNpWfcPXCLYSJCCgfPy30sEtuzkDraJgqF35dzgmz6xlvH/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/ungap__structured-clone": "^1.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "github-slugger": "^2.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-wiki-link": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/mdast-util-wiki-link/-/mdast-util-wiki-link-0.1.2.tgz",
@@ -2086,6 +2112,20 @@
         "@types/mdast": "^4.0.0",
         "mdast-util-to-markdown": "^2.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-toc": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/remark-toc/-/remark-toc-9.0.0.tgz",
+      "integrity": "sha512-KJ9txbo33GjDAV1baHFze7ij4G8c7SGYoY8Kzsm2gzFpbhL/bSoVpMMzGa3vrNDSWASNd/3ppAqL7cP2zD6JIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-toc": "^7.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zenmd",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zenmd",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "dependencies": {
         "chalk": "^5.3.0",
         "glob": "^10.3.10",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "remark-parse": "^11.0.0",
     "remark-parse-frontmatter": "^1.0.3",
     "remark-rehype": "^11.0.0",
+    "remark-toc": "^9.0.0",
     "remark-wiki-link": "^2.0.1",
     "unified": "^11.0.4",
     "unist-util-visit": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "static site generator",
     "ssg"
   ],
-  "version": "0.0.22",
+  "version": "0.0.23",
   "repository": {
     "type": "git",
     "url": "https://github.com/randomor/zenmd.git"

--- a/src/parser.js
+++ b/src/parser.js
@@ -5,6 +5,7 @@ import remarkRehype from "remark-rehype";
 import remarkWikiLink from "remark-wiki-link";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkParseFrontmatter from "remark-parse-frontmatter";
+import remarkToc from "remark-toc";
 import rehypeSlug from "rehype-slug";
 import rehypeRaw from "rehype-raw";
 import rehypeStringify from "rehype-stringify";
@@ -45,6 +46,9 @@ export const configParser = (
     // Obsidian image embeds are pre-processed into standard Markdown images in
     // parseMarkdown, so no special remark plugin is needed for them here.
     .use(remarkGfm)
+    // 3. remarkToc: Generate table of contents when a `## Contents` or
+    //    `## Table of contents` heading is present.
+    .use(remarkToc)
     // 4. Link normalizer for .md extensions in standard links.
     .use(() => (tree) => {
       visit(tree, "link", (node) => {

--- a/src/parser.test.js
+++ b/src/parser.test.js
@@ -68,6 +68,14 @@ describe("configParser", () => {
     const file = await parser.process("[[Example]]");
     assert.match(file.value, /href="..\/example.html"/);
   });
+
+  it("generates table of contents from headings", async () => {
+    const sourceFile = "./src/__test__/example.md";
+    const parser = configParser(sourceFile, inputFolder, outputFolder);
+    const md = "# Title\n\n## Table of contents\n\n## Section";
+    const file = await parser.process(md);
+    assert.match(file.value, /href=\"#section\"/);
+  });
 });
 
 describe("Obsidian Image Processing", () => {


### PR DESCRIPTION
## Summary
- integrate remark-toc to generate TOC sections automatically
- document TOC feature in README and references
- include new remark-toc dependency
- test that a Table of Contents is produced when a matching heading exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68476f3896e88327a462173103b3c4d9